### PR TITLE
Update lambda module call to point at TF registry rather than Github

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -1,5 +1,6 @@
 module "lambda" {
-  source = "github.com/claranet/terraform-aws-lambda?ref=v1.1.0"
+  source  = "claranet/lambda/aws"
+  version = "1.1.0"
 
   function_name = var.name
   description   = "Manages ASG instance alarms"


### PR DESCRIPTION
Just a small tweak to follow best practices and point this module at the Terraform registry, rather than directly at Github.